### PR TITLE
Fix render_image for MarkdownRenderer

### DIFF
--- a/marko/md_renderer.py
+++ b/marko/md_renderer.py
@@ -128,7 +128,7 @@ class MarkdownRenderer(Renderer):
         title = (
             ' "{}"'.format(element.title.replace('"', '\\"')) if element.title else ""
         )
-        return template.format(element.children, element.dest, title)
+        return template.format(self.render_children(element), element.dest, title)
 
     def render_literal(self, element):
         return "\\" + element.children


### PR DESCRIPTION
When I call the follows:

```py
from marko import Markdown
from marko.md_renderer import MarkdownRenderer

markdown = Markdown(renderer=MarkdownRenderer)
markdown("![Build Status](https://github.com/frostming/marko/workflows/Tests/badge.svg)")
```

Current output looks incorrect:

```
'![[<marko.inline.RawText object at 0x7fa4640bcda0>]](https://github.com/frostming/marko/workflows/Tests/badge.svg)\n\n'
```

But output in This PR is:

```
'![Build Status](https://github.com/frostming/marko/workflows/Tests/badge.svg)\n\n'
```
