### PR TITLE
Remove double newline in markdown renderer paragraph

### DIFF
--- a/marko/md_renderer.py
+++ b/marko/md_renderer.py
@@ -31,8 +31,7 @@ class MarkdownRenderer(Renderer):
 
     def render_paragraph(self, element):
         children = self.render_children(element)
-        tail = "\n" if element._tight else "\n\n"
-        line = self._prefix + children + tail
+        line = self._prefix + children + "\n"
         self._prefix = self._second_prefix
         return line
 


### PR DESCRIPTION
The extra newlines cause the produced markdown to fail most markdown linters.

I appreciate this is a subjective PR, but the linters I've checked the output on are not happy with the extra newlines.