### PR TITLE
Reflect dropped support for Python < 3.6 in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 Marko is a markdown parser written in pure Python that complies [CommonMark's spec v0.29][spec].
 It is designed to be highly extensible, see [Extend Marko](#extend-marko) for details.
 
-Marko requires Python2.7, Python 3.6 or higher.
+Marko requires Python 3.6 or higher.
 
 ## Why Marko
 


### PR DESCRIPTION
Support for Python 2.7 has been dropped with Marko v1.0.0.