### PR TITLE
Add py.typed.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,4 +2,4 @@
 from setuptools import setup
 
 
-setup(name="marko")
+setup(name="marko", package_data={'marko': ['py.typed']})


### PR DESCRIPTION
Add py.typed when installing, so language servers pick up that the package is typed.