### PR TITLE
Querying element Markdown type

### DIFF
--- a/marko/block.py
+++ b/marko/block.py
@@ -5,6 +5,7 @@ import re
 from . import inline, patterns
 from .helpers import Source, is_paired, normalize_label, is_type_check
 from .parser import Parser
+from .element import Element
 
 if is_type_check():
     from typing import Any, Optional, Match, Dict, Union, Tuple, List as _List
@@ -26,7 +27,7 @@ __all__ = (
 )
 
 
-class BlockElement:
+class BlockElement(Element):
     """Any block element should inherit this class"""
 
     #: Use to denote the precedence in parsing

--- a/marko/element.py
+++ b/marko/element.py
@@ -9,7 +9,7 @@ class Element:
     This class should not be subclassed by any other classes beside these.
     """
     @classmethod
-    def get_element_type(cls, snake_case=False):  # type: (Any) -> str
+    def get_type(cls, snake_case=False):  # type: (Any) -> str
         """
         Return the Markdown element type that the object represents.
 

--- a/marko/element.py
+++ b/marko/element.py
@@ -3,8 +3,9 @@ from .helpers import camel_to_snake_case, is_type_check
 if is_type_check():
     from typing import Any
 
+
 class Element:
-    """This class holds attributes common to both the BlockElement and 
+    """This class holds attributes common to both the BlockElement and
     InlineElement classes.
     This class should not be subclassed by any other classes beside these.
     """

--- a/marko/element.py
+++ b/marko/element.py
@@ -1,0 +1,10 @@
+class Element:
+    @classmethod
+    def get_element_type(cls):  # type: () -> str
+        """Return the Markdown element type that the object represents."""
+
+        # Prevent override of BlockElement and InlineElement
+        if cls.override and cls.__base__ not in Element.__subclasses__():
+            return cls.__base__.__name__
+        else:
+            return cls.__name__

--- a/marko/element.py
+++ b/marko/element.py
@@ -1,10 +1,24 @@
+from .helpers import camel_to_snake_case, is_type_check
+
+if is_type_check():
+    from typing import Any
+
 class Element:
+    """This class holds attributes common to both the BlockElement and 
+    InlineElement classes.
+    This class should not be subclassed by any other classes beside these.
+    """
     @classmethod
-    def get_element_type(cls):  # type: () -> str
-        """Return the Markdown element type that the object represents."""
+    def get_element_type(cls, snake_case=False):  # type: (Any) -> str
+        """
+        Return the Markdown element type that the object represents.
+
+        :param snake_case: Return the element type name in snake case if True
+        """
 
         # Prevent override of BlockElement and InlineElement
         if cls.override and cls.__base__ not in Element.__subclasses__():
-            return cls.__base__.__name__
+            name = cls.__base__.__name__
         else:
-            return cls.__name__
+            name = cls.__name__
+        return camel_to_snake_case(name) if snake_case else name

--- a/marko/inline.py
+++ b/marko/inline.py
@@ -5,6 +5,7 @@ import re
 
 from .helpers import is_type_check
 from . import inline_parser, patterns
+from .element import Element
 
 if is_type_check():
     from typing import Pattern, Match, Iterator, Union
@@ -25,7 +26,7 @@ __all__ = (
 )
 
 
-class InlineElement:
+class InlineElement(Element):
     """Any inline element should inherit this class"""
 
     #: Use to denote the precedence in parsing.

--- a/marko/parser.py
+++ b/marko/parser.py
@@ -45,15 +45,7 @@ class Parser:
                 "The element should be a subclass of either `BlockElement` or "
                 "`InlineElement`."
             )
-        if not element.override:
-            dest[element.__name__] = element
-        else:
-            for cls in element.__bases__:
-                if cls.__name__ in dest:
-                    dest[cls.__name__] = element
-                    break
-            else:
-                dest[element.__name__] = element
+        dest[element.get_element_type()] = element
 
     def parse(self, source_or_text):
         # type: (Union[Source, AnyStr]) -> Union[List[block.BlockElement], block.BlockElement]

--- a/marko/parser.py
+++ b/marko/parser.py
@@ -107,11 +107,11 @@ class Parser:
         return [e for e in self.inline_elements.values() if not e.virtual]
 
 
-from . import block, inline, inline_parser  # noqa
+from . import block, inline, inline_parser, element  # noqa
 
 if is_type_check():
     from typing import Type, Union, Dict, AnyStr, List
 
     BlockElementType = Type[block.BlockElement]
     InlineElementType = Type[inline.InlineElement]
-    ElementType = Union[BlockElementType, InlineElementType]
+    ElementType = Type[element.Element]

--- a/marko/parser.py
+++ b/marko/parser.py
@@ -21,11 +21,11 @@ class Parser:
         self.block_elements = {}  # type: Dict[str, BlockElementType]
         self.inline_elements = {}  # type: Dict[str, InlineElementType]
 
-        for element in itertools.chain(
+        for el in itertools.chain(
             (getattr(block, name) for name in block.__all__),
             (getattr(inline, name) for name in inline.__all__),
         ):
-            self.add_element(element)
+            self.add_element(el)
 
     def add_element(self, element):  # type: (ElementType) -> None
         """Add an element to the parser.

--- a/marko/parser.py
+++ b/marko/parser.py
@@ -45,7 +45,7 @@ class Parser:
                 "The element should be a subclass of either `BlockElement` or "
                 "`InlineElement`."
             )
-        dest[element.get_element_type()] = element
+        dest[element.get_type()] = element
 
     def parse(self, source_or_text):
         # type: (Union[Source, AnyStr]) -> Union[List[block.BlockElement], block.BlockElement]

--- a/marko/renderer.py
+++ b/marko/renderer.py
@@ -60,7 +60,7 @@ class Renderer:
         # Store the root node to provide some context to render functions
         if not self.root_node:
             self.root_node = element  # type: ignore
-        render_func = getattr(self, self._cls_to_func_name(element.__class__), None)
+        render_func = getattr(self, self._cls_to_func_name(element), None)
         if render_func is not None and (
             getattr(render_func, "_force_delegate", False) or self.delegate
         ):
@@ -82,18 +82,12 @@ class Renderer:
         rendered = [self.render(child) for child in element.children]  # type: ignore
         return "".join(rendered)
 
-    def _cls_to_func_name(self, klass):  # type: (ElementType) -> str
-        from .block import parser
-
-        element_types = itertools.chain(
-            parser.block_elements.items(),  # type: ignore
-            parser.inline_elements.items(),  # type: ignore
-        )
-        for name, cls in element_types:
-            if cls is klass:
-                return "render_" + camel_to_snake_case(name)
-
-        return "render_children"
+    def _cls_to_func_name(self, element):  # type: (ElementType) -> str
+        try:
+            name = element.get_element_type()
+            return "render_" + camel_to_snake_case(name)
+        except AttributeError:
+            return "render_children"
 
 
 def force_delegate(func):

--- a/marko/renderer.py
+++ b/marko/renderer.py
@@ -2,7 +2,6 @@
 Base renderer class
 """
 import html
-import itertools
 import re
 
 from .helpers import is_type_check

--- a/marko/renderer.py
+++ b/marko/renderer.py
@@ -5,15 +5,14 @@ import html
 import itertools
 import re
 
-from .helpers import camel_to_snake_case, is_type_check
+from .helpers import is_type_check
 
 if is_type_check():
-    from typing import Any, Union
+    from typing import Any, Union, List, TypeVar
     from .inline import InlineElement
     from .block import BlockElement
-    from .parser import ElementType
-
-    Element = Union[BlockElement, InlineElement]
+    from .element import Element
+    T = TypeVar("T")
 
 
 class Renderer:
@@ -60,7 +59,7 @@ class Renderer:
         # Store the root node to provide some context to render functions
         if not self.root_node:
             self.root_node = element  # type: ignore
-        render_func = getattr(self, self._cls_to_func_name(element), None)
+        render_func = getattr(self, self._el_to_func_name(element), None)
         if render_func is not None and (
             getattr(render_func, "_force_delegate", False) or self.delegate
         ):
@@ -82,10 +81,9 @@ class Renderer:
         rendered = [self.render(child) for child in element.children]  # type: ignore
         return "".join(rendered)
 
-    def _cls_to_func_name(self, element):  # type: (ElementType) -> str
+    def _el_to_func_name(self, element):  # type: (Union[Element, List[T]]) -> str
         try:
-            name = element.get_element_type()
-            return "render_" + camel_to_snake_case(name)
+            return "render_" + element.get_element_type(snake_case=True)
         except AttributeError:
             return "render_children"
 

--- a/marko/renderer.py
+++ b/marko/renderer.py
@@ -83,7 +83,7 @@ class Renderer:
 
     def _el_to_func_name(self, element):  # type: (Union[Element, List[T]]) -> str
         try:
-            return "render_" + element.get_element_type(snake_case=True)
+            return "render_" + element.get_type(snake_case=True)
         except AttributeError:
             return "render_children"
 

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -86,7 +86,7 @@ class TestExtension:
         markdown = marko.Markdown(extensions=[MyExtension])
         markdown._setup_extensions()
         assert markdown.parser.block_elements["Heading"] is MyHeading
-        assert markdown.parser.block_elements["Heading"].get_element_type() == "Heading"
+        assert markdown.parser.block_elements["Heading"].get_type() == "Heading"
 
     def test_extension_override_non_base_element(self):
         class MyHeading(block.BlockElement):
@@ -98,7 +98,7 @@ class TestExtension:
         markdown = marko.Markdown(extensions=[MyExtension])
         markdown._setup_extensions()
         assert markdown.parser.block_elements["MyHeading"] is MyHeading
-        assert markdown.parser.block_elements["MyHeading"].get_element_type() == "MyHeading"
+        assert markdown.parser.block_elements["MyHeading"].get_type() == "MyHeading"
 
     def test_extension_with_illegal_element(self):
         class MyExtension:

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -86,6 +86,7 @@ class TestExtension:
         markdown = marko.Markdown(extensions=[MyExtension])
         markdown._setup_extensions()
         assert markdown.parser.block_elements["Heading"] is MyHeading
+        assert markdown.parser.block_elements["Heading"].get_element_type() == "Heading"
 
     def test_extension_override_non_base_element(self):
         class MyHeading(block.BlockElement):
@@ -97,6 +98,7 @@ class TestExtension:
         markdown = marko.Markdown(extensions=[MyExtension])
         markdown._setup_extensions()
         assert markdown.parser.block_elements["MyHeading"] is MyHeading
+        assert markdown.parser.block_elements["MyHeading"].get_element_type() == "MyHeading"
 
     def test_extension_with_illegal_element(self):
         class MyExtension:


### PR DESCRIPTION
From #96 

I realised that this function would need to apply to both `BlockElement`s and `InlineElement`s, and after creating a parent class, I got carried away looking for other places where Markdown type was checked!

Please consider this a work in progress, I'd be happy to scale back any changes here