### PR TITLE
Fix dict spelling

### DIFF
--- a/marko/parser.py
+++ b/marko/parser.py
@@ -12,7 +12,7 @@ class Parser:
 
     Attributes:
         block_elements(dict): a dict of name: block_element pairs
-        inlin_elements(dict): a dict of name: inlin_element pairs
+        inline_elements(dict): a dict of name: inline_element pairs
 
     :param \*extras: extra elements to be included in parsing process.
     """


### PR DESCRIPTION
I noticed that in https://marko-py.readthedocs.io/en/latest/api.html#marko.parser.Parser, `inline_elements` and `inline_element` are spelled `inlin_elements` and `inlin_element`. This PR updates the doc so that it matches the source.