### PR TITLE
Implement basic rendering functionality for LaTeX

### DIFF
--- a/marko/ext/latex_renderer.py
+++ b/marko/ext/latex_renderer.py
@@ -18,7 +18,7 @@ class LatexRenderer(Renderer):
     # Header levels that will be numbered. Default none.
     # It could be a list of header levels (ex. [1, 2]) or header names ['part', 'section']
     # TODO: add unit test
-    numbered_headers: list[Union[int, str]]
+    numbered_headers: List[Union[int, str]]
 
     def __init__(self):
         super().__init__()

--- a/marko/ext/latex_renderer.py
+++ b/marko/ext/latex_renderer.py
@@ -2,7 +2,7 @@
 LaTeX renderer
 """
 import logging
-from typing import List, Optional, Union
+from typing import List, Optional, Set, Union
 
 from marko import Renderer
 
@@ -12,8 +12,8 @@ _logger = logging.getLogger(__name__)
 class LatexRenderer(Renderer):
     """Render the parsed Markdown to LaTeX format."""
 
-    packages: set[str]
-    graphic_paths: set[str]
+    packages: Set[str]
+    graphic_paths: Set[str]
 
     # Header levels that will be numbered. Default none.
     # It could be a list of header levels (ex. [1, 2]) or header names ['part', 'section']

--- a/marko/ext/latex_renderer.py
+++ b/marko/ext/latex_renderer.py
@@ -116,7 +116,7 @@ class LatexRenderer(Renderer):
     def render_auto_link(self, element):
         return self._simple_command("url", element.dest)
 
-    def render_link_ref_def(self, elemement):
+    def render_link_ref_def(self, element):
         # TODO: check if a special handling is needed for link_ref_def
         return ""
 

--- a/marko/ext/latex_renderer.py
+++ b/marko/ext/latex_renderer.py
@@ -13,7 +13,6 @@ class LatexRenderer(Renderer):
     """Render the parsed Markdown to LaTeX format."""
 
     packages: Set[str]
-    graphic_paths: Set[str]
 
     # Header levels that will be numbered. Default none.
     # It could be a list of header levels (ex. [1, 2]) or header names ['part', 'section']
@@ -23,7 +22,6 @@ class LatexRenderer(Renderer):
     def __init__(self):
         super().__init__()
         self.packages = set()
-        self.graphic_paths = set()
         self.numbered_headers = []
 
     def render_document(self, element):
@@ -33,10 +31,6 @@ class LatexRenderer(Renderer):
         items = [self._simple_command("documentclass", "article")]
         # add used packages
         items.extend(self._simple_command("usepackage", p) for p in self.packages)
-        # add graphics paths
-        if self.graphic_paths:
-            graphic_paths = "".join(f" {{{p}}} " for p in self.graphic_paths)
-            items.append(self._simple_command("graphicspath", graphic_paths))
         # add inner content
         items.append(self._environment("document", children))
         return "\n".join(items)
@@ -174,10 +168,6 @@ class LatexRenderer(Renderer):
         if content is None:
             return f"\\{cmd_name}"
         return f"\\{cmd_name}{{{content}}}"
-
-    @staticmethod
-    def _scope_command(cmd_name: str, content: str) -> str:
-        return f"{{\\{cmd_name} {content}}}"
 
     @staticmethod
     def _environment(env_name: str, content: str, options: Optional[List[str]] = None) -> str:

--- a/marko/ext/latex_renderer.py
+++ b/marko/ext/latex_renderer.py
@@ -1,0 +1,185 @@
+"""
+LaTeX renderer
+"""
+import logging
+from typing import List, Optional, Union
+
+from marko import Renderer
+
+_logger = logging.getLogger(__name__)
+
+
+class LatexRenderer(Renderer):
+    """Render the parsed Markdown to LaTeX format."""
+
+    packages: set[str]
+    graphic_paths: set[str]
+
+    # Header levels that will be numbered. Default none.
+    # It could be a list of header levels (ex. [1, 2]) or header names ['part', 'section']
+    # TODO: add unit test
+    numbered_headers: list[Union[int, str]]
+
+    def __init__(self):
+        super().__init__()
+        self.packages = set()
+        self.graphic_paths = set()
+        self.numbered_headers = []
+
+    def render_document(self, element):
+        # should come first to collect needed packages
+        children = self.render_children(element)
+        # create document parts
+        items = [self._simple_command("documentclass", "article")]
+        # add used packages
+        items.extend(self._simple_command("usepackage", p) for p in self.packages)
+        # add graphics paths
+        if self.graphic_paths:
+            graphic_paths = "".join(f" {{{p}}} " for p in self.graphic_paths)
+            items.append(self._simple_command("graphicspath", graphic_paths))
+        # add inner content
+        items.append(self._environment("document", children))
+        return "\n".join(items)
+
+    def render_paragraph(self, element):
+        children = self.render_children(element)
+        if element._tight:
+            return children
+        else:
+            return f"{children}\n"
+
+    def render_blank_line(self, element):
+        return "\n"
+
+    def render_line_break(self, element):
+        if element.soft:
+            return "\n"
+        return "\\\\\n"
+
+    def render_list(self, element):
+        children = self.render_children(element)
+        env = "enumerate" if element.ordered else "itemize"
+        # TODO: check how to handle element.start with ordered list
+        if element.start:
+            _logger.warning("Setting the starting number of the list is not supported!")
+        return self._environment(env, children)
+
+    def render_list_item(self, element):
+        children = self.render_children(element)
+        return f"\\item {children}\n"
+
+    def render_quote(self, element):
+        self.packages.add("csquotes")
+        children = self.render_children(element)
+        return self._environment("displayquote", children)
+
+    def render_fenced_code(self, element):
+        self.packages.add("listings")
+        language = self._escape_latex(element.lang)
+        return self._environment("lstlisting", element.children[0].children, [f"language={language}"])
+
+    def render_code_block(self, element):
+        return self._environment("verbatim", element.children[0].children)
+
+    def render_thematic_break(self, element):
+        return "\\noindent\\rule{\\textwidth}{1pt}\n"
+
+    def render_heading(self, element):
+        children = self.render_children(element)
+        headers = ["part", "section", "subsection", "subsubsection", "paragraph", "subparagraph"]
+        header = headers[element.level - 1]
+        if (element.level not in self.numbered_headers) and (header not in self.numbered_headers):
+            header += "*"
+        return self._simple_command(header, children) + "\n"
+
+    def render_setext_heading(self, element):
+        return self.render_heading(element)
+
+    def render_emphasis(self, element):
+        children = self.render_children(element)
+        return self._simple_command("textit", children)
+
+    def render_strong_emphasis(self, element):
+        children = self.render_children(element)
+        return self._simple_command("textbf", children)
+
+    def render_code_span(self, element):
+        children = self._escape_latex(element.children)
+        return self._simple_command("texttt", children)
+
+    def render_link(self, element):
+        if element.title:
+            _logger.warning("Setting a title for links is not supported!")
+        body = self.render_children(element)
+        return self._command("href", arguments=[element.dest, body])
+
+    def render_auto_link(self, element):
+        return self._simple_command("url", element.dest)
+
+    def render_link_ref_def(self, elemement):
+        # TODO: check if a special handling is needed for link_ref_def
+        return ""
+
+    def render_image(self, element):
+        self.packages.add("graphicx")
+        # TODO: check if alt (element.children) or element.title might be used!
+        return self._simple_command("includegraphics", element.dest)
+
+    def render_html_block(self, element):
+        _logger.warning("Rendering HTML is not supported!")
+        return ""
+
+    def render_inline_html(self, element):
+        _logger.warning("Rendering HTML is not supported!")
+        return ""
+
+    def render_plain_text(self, element):
+        if isinstance(element.children, str):
+            return self._escape_latex(element.children)
+        return self.render_children(element)
+
+    def render_literal(self, element):
+        return self.render_raw_text(element)
+
+    def render_raw_text(self, element):
+        return self._escape_latex(element.children)
+
+    @staticmethod
+    def _escape_latex(text: str) -> str:
+        # Special LaTeX Character:  # $ % ^ & _ { } ~ \
+        special = {
+            "#": "\\#",
+            "$": "\\$",
+            "%": "\\%",
+            "&": "\\&",
+            "_": "\\_",
+            "{": "\\{",
+            "}": "\\}",
+            "^": "\\^{}",
+            "~": "\\~{}",
+            "\\": "\\textbackslash{}",
+        }
+
+        return "".join(special.get(s, s) for s in text)
+
+    @staticmethod
+    def _command(cmd_name: str, arguments: Optional[List[str]] = None, options: Optional[List[str]] = None) -> str:
+        options_str = f"[{','.join(options)}]" if options else ""
+        arguments = arguments or []
+        arguments_str = "".join(f"{{{a}}}" for a in arguments)
+        return f"\\{cmd_name}{options_str}{arguments_str}"
+
+    @staticmethod
+    def _simple_command(cmd_name: str, content: Optional[str] = None) -> str:
+        if content is None:
+            return f"\\{cmd_name}"
+        return f"\\{cmd_name}{{{content}}}"
+
+    @staticmethod
+    def _scope_command(cmd_name: str, content: str) -> str:
+        return f"{{\\{cmd_name} {content}}}"
+
+    @staticmethod
+    def _environment(env_name: str, content: str, options: Optional[List[str]] = None) -> str:
+        options_str = f"[{','.join(options)}]" if options else ""
+        return f"\\begin{{{env_name}}}{options_str}\n{content}\\end{{{env_name}}}\n"

--- a/marko/ext/latex_renderer.py
+++ b/marko/ext/latex_renderer.py
@@ -51,7 +51,7 @@ class LatexRenderer(Renderer):
         children = self.render_children(element)
         env = "enumerate" if element.ordered else "itemize"
         # TODO: check how to handle element.start with ordered list
-        if element.start:
+        if element.start and element.start != 1:
             _logger.warning("Setting the starting number of the list is not supported!")
         return self._environment(env, children)
 

--- a/marko/ext/latex_renderer.py
+++ b/marko/ext/latex_renderer.py
@@ -111,7 +111,6 @@ class LatexRenderer(Renderer):
         return self._simple_command("url", element.dest)
 
     def render_link_ref_def(self, element):
-        # TODO: check if a special handling is needed for link_ref_def
         return ""
 
     def render_image(self, element):

--- a/marko/html_renderer.py
+++ b/marko/html_renderer.py
@@ -68,7 +68,7 @@ class HTMLRenderer(Renderer):
     def render_blank_line(self, element):
         return ""
 
-    def render_link_ref_def(self, elemement):
+    def render_link_ref_def(self, element):
         return ""
 
     def render_emphasis(self, element):

--- a/marko/md_renderer.py
+++ b/marko/md_renderer.py
@@ -107,7 +107,7 @@ class MarkdownRenderer(Renderer):
         self._prefix = self._second_prefix
         return result
 
-    def render_link_ref_def(self, elemement):
+    def render_link_ref_def(self, element):
         return ""
 
     def render_emphasis(self, element):

--- a/tests/test_latex.py
+++ b/tests/test_latex.py
@@ -12,7 +12,7 @@ def test_render_paragraph():
         This is
          another paragraph.
 
-        This has line
+        This has line   \n\
            break!
         """
     latex = """\

--- a/tests/test_latex.py
+++ b/tests/test_latex.py
@@ -280,6 +280,27 @@ def test_render_image():
     _assert_latex(markdown, latex)
 
 
+def test_render_html(caplog):
+    markdown = """\
+        This HTML tag <br> will be ignored as well as the following HTML block.
+
+        <table>
+          <tr><th>X</th><th>Y</th></tr>
+          <tr><td>1</td><td>2</td></tr>
+        </table>
+        """
+    latex = """\
+        \\documentclass{article}
+        \\begin{document}
+        This HTML tag  will be ignored as well as the following HTML block.
+
+        \\end{document}
+        """
+
+    _assert_latex(markdown, latex)
+    assert "Rendering HTML is not supported!" in caplog.text
+
+
 def _assert_latex(markdown: str, latex: str):
     ast_converter = Markdown(renderer=ASTRenderer)
     print(ast_converter(dedent(markdown)))

--- a/tests/test_latex.py
+++ b/tests/test_latex.py
@@ -1,0 +1,287 @@
+from textwrap import dedent
+
+from marko import Markdown
+from marko.ext.latex_renderer import LatexRenderer
+from marko.ast_renderer import ASTRenderer
+
+
+def test_render_paragraph():
+    markdown = """\
+        This is a paragraph.
+
+        This is
+         another paragraph.
+
+        This has line    
+           break!
+        """
+    latex = """\
+        \\documentclass{article}
+        \\begin{document}
+        This is a paragraph.
+        
+        This is
+        another paragraph.
+        
+        This has line\\\\
+        break!
+        \\end{document}
+        """
+
+    _assert_latex(markdown, latex)
+
+
+def test_render_special_characters():
+    markdown = "\\# This paragraph contains $pecial_characters like: {%, ^, ~ & \\\\}"
+    latex = """\
+        \\documentclass{article}
+        \\begin{document}
+        \\# This paragraph contains \\$pecial\\_characters like: \\{\\%, \\^{}, \\~{} \\& \\textbackslash{}\\}
+        \\end{document}
+        """
+
+    _assert_latex(markdown, latex)
+
+
+def test_render_format():
+    markdown = "This `test case` *tests* **basic** *text **formatting***."
+    latex = """\
+        \\documentclass{article}
+        \\begin{document}
+        This \\texttt{test case} \\textit{tests} \\textbf{basic} \\textit{text \\textbf{formatting}}.
+        \\end{document}
+        """
+
+    _assert_latex(markdown, latex)
+
+
+def test_render_unordered_list():
+    markdown = """\
+        Items:
+        * Item 1
+        * Item 2
+        * Item 3
+        """
+    latex = """\
+        \\documentclass{article}
+        \\begin{document}
+        Items:
+        \\begin{itemize}
+        \\item Item 1
+        \\item Item 2
+        \\item Item 3
+        \\end{itemize}
+        \\end{document}
+        """
+
+    _assert_latex(markdown, latex)
+
+
+def test_render_ordered_list():
+    markdown = """\
+        Items:
+        1. Item 1
+        1. Item 2
+        1. Item 3
+        """
+    latex = """\
+        \\documentclass{article}
+        \\begin{document}
+        Items:
+        \\begin{enumerate}
+        \\item Item 1
+        \\item Item 2
+        \\item Item 3
+        \\end{enumerate}
+        \\end{document}
+        """
+
+    _assert_latex(markdown, latex)
+
+
+def test_render_headers():
+    markdown = """\
+        # Header 1
+        Paragraph 1.
+        
+        ## Header 2
+        Paragraph 2.
+        
+        ### Header 3
+        Paragraph 3.
+        
+        #### Header 4
+        Paragraph 4.
+        
+        ##### Header 5
+        Paragraph 5.
+        
+        ###### Header 6
+        Paragraph 6.
+
+        Alternate Header 1
+        ==================
+        Alternate 1
+
+        Alternate Header 2
+        ------------------
+        Alternate 2
+        """
+    latex = """\
+        \\documentclass{article}
+        \\begin{document}
+        \\part*{Header 1}
+        Paragraph 1.
+
+        \\section*{Header 2}
+        Paragraph 2.
+
+        \\subsection*{Header 3}
+        Paragraph 3.
+
+        \\subsubsection*{Header 4}
+        Paragraph 4.
+
+        \\paragraph*{Header 5}
+        Paragraph 5.
+
+        \\subparagraph*{Header 6}
+        Paragraph 6.
+
+        \\part*{Alternate Header 1}
+        Alternate 1
+
+        \\section*{Alternate Header 2}
+        Alternate 2
+        \\end{document}
+        """
+
+    _assert_latex(markdown, latex)
+
+
+def test_render_code():
+    markdown = """\
+        The following is a code block:
+
+            Text enclosed inside \\texttt{verbatim} environment
+            is printed directly and all \\LaTeX{} commands are ignored.
+
+        While the following is a fenced code block:
+
+        ```python
+        def do_while():
+            while(not_finished):
+                print("do something ...")
+            print("finished!")
+        ```
+        """
+    latex = """\
+        \\documentclass{article}
+        \\usepackage{listings}
+        \\begin{document}
+        The following is a code block:
+
+        \\begin{verbatim}
+        Text enclosed inside \\texttt{verbatim} environment
+        is printed directly and all \\LaTeX{} commands are ignored.
+        \\end{verbatim}
+
+        While the following is a fenced code block:
+
+        \\begin{lstlisting}[language=python]
+        def do_while():
+            while(not_finished):
+                print("do something ...")
+            print("finished!")
+        \\end{lstlisting}
+        \\end{document}
+        """
+
+    _assert_latex(markdown, latex)
+
+
+def test_render_links():
+    markdown = """\
+        [marko](https://github.com/frostming/marko "marko on GitHub"): A markdown parser with high extensibility.
+
+        Documentation: <https://marko-py.readthedocs.io/en/latest/>.
+        """
+    latex = """\
+        \\documentclass{article}
+        \\begin{document}
+        \\href{https://github.com/frostming/marko}{marko}: A markdown parser with high extensibility.
+
+        Documentation: \\url{https://marko-py.readthedocs.io/en/latest/}.
+        \\end{document}
+        """
+
+    _assert_latex(markdown, latex)
+
+
+def test_render_quote():
+    markdown = """\
+        They used to say:
+
+        > Take care of
+        > important quotes.
+        """
+    latex = """\
+        \\documentclass{article}
+        \\usepackage{csquotes}
+        \\begin{document}
+        They used to say:
+
+        \\begin{displayquote}
+        Take care of
+        important quotes.
+        \\end{displayquote}
+        \\end{document}
+        """
+
+    _assert_latex(markdown, latex)
+
+
+def test_render_thematic_break():
+    markdown = """\
+        This paragraph is above the horizontal line.
+        
+        * * * 
+
+        While this paragraph is below the horizontal line.
+        """
+    latex = """\
+        \\documentclass{article}
+        \\begin{document}
+        This paragraph is above the horizontal line.
+        
+        \\noindent\\rule{\\textwidth}{1pt}
+
+        While this paragraph is below the horizontal line.
+        \\end{document}
+        """
+
+    _assert_latex(markdown, latex)
+
+
+def test_render_image():
+    markdown = """\
+        ## A simple image
+        ![This is a sample for an image](sample.jpg "Title is ignored!")
+        """
+    latex = """\
+        \\documentclass{article}
+        \\usepackage{graphicx}
+        \\begin{document}
+        \\section*{A simple image}
+        \\includegraphics{sample.jpg}
+        \\end{document}
+        """
+
+    _assert_latex(markdown, latex)
+
+
+def _assert_latex(markdown: str, latex: str):
+    ast_converter = Markdown(renderer=ASTRenderer)
+    print(ast_converter(dedent(markdown)))
+    latex_converter = Markdown(renderer=LatexRenderer)
+    assert latex_converter(dedent(markdown)) == dedent(latex)

--- a/tests/test_latex.py
+++ b/tests/test_latex.py
@@ -202,16 +202,21 @@ def test_render_code():
 
 def test_render_links():
     markdown = """\
-        [marko](https://github.com/frostming/marko "marko on GitHub"): A markdown parser with high extensibility.
+        [marko](https://github.com/frostming/marko "marko on GitHub"): A markdown parser with high extensibility,
+          see [Extensions][extensions] for details.
 
         Documentation: <https://marko-py.readthedocs.io/en/latest/>.
+
+        [extensions]: https://github.com/frostming/marko#extensions
         """
     latex = """\
         \\documentclass{article}
         \\begin{document}
-        \\href{https://github.com/frostming/marko}{marko}: A markdown parser with high extensibility.
+        \\href{https://github.com/frostming/marko}{marko}: A markdown parser with high extensibility,
+        see \\href{https://github.com/frostming/marko#extensions}{Extensions} for details.
 
         Documentation: \\url{https://marko-py.readthedocs.io/en/latest/}.
+
         \\end{document}
         """
 

--- a/tests/test_latex.py
+++ b/tests/test_latex.py
@@ -132,10 +132,10 @@ def test_render_headers():
         \\part*{Header 1}
         Paragraph 1.
 
-        \\section{Header 2}
+        \\section*{Header 2}
         Paragraph 2.
 
-        \\subsection{Header 3}
+        \\subsection*{Header 3}
         Paragraph 3.
 
         \\subsubsection*{Header 4}
@@ -150,16 +150,12 @@ def test_render_headers():
         \\part*{Alternate Header 1}
         Alternate 1
 
-        \\section{Alternate Header 2}
+        \\section*{Alternate Header 2}
         Alternate 2
         \\end{document}
         """
 
-    md = Markdown()
-    parsed = md.parse(dedent(markdown))
-    renderer = LatexRenderer(numbered_headers=[2, "subsection"])  # number section and subsection
-    with renderer as r:
-        assert r.render(parsed) == dedent(latex)
+    _assert_latex(markdown, latex)
 
 
 def test_render_code():

--- a/tests/test_latex.py
+++ b/tests/test_latex.py
@@ -57,6 +57,7 @@ def test_render_format():
 def test_render_unordered_list():
     markdown = """\
         Items:
+        
         * Item 1
         * Item 2
         * Item 3
@@ -65,6 +66,7 @@ def test_render_unordered_list():
         \\documentclass{article}
         \\begin{document}
         Items:
+        
         \\begin{itemize}
         \\item Item 1
         \\item Item 2
@@ -79,6 +81,7 @@ def test_render_unordered_list():
 def test_render_ordered_list():
     markdown = """\
         Items:
+        
         1. Item 1
         1. Item 2
         1. Item 3
@@ -87,6 +90,7 @@ def test_render_ordered_list():
         \\documentclass{article}
         \\begin{document}
         Items:
+        
         \\begin{enumerate}
         \\item Item 1
         \\item Item 2
@@ -96,6 +100,29 @@ def test_render_ordered_list():
         """
 
     _assert_latex(markdown, latex)
+
+
+def test_render_ordered_list_change_start(caplog):
+    markdown = """\
+        Items:
+        
+        5. Item 5
+        5. Item 6
+        """
+    latex = """\
+        \\documentclass{article}
+        \\begin{document}
+        Items:
+        
+        \\begin{enumerate}
+        \\item Item 5
+        \\item Item 6
+        \\end{enumerate}
+        \\end{document}
+        """
+
+    _assert_latex(markdown, latex)
+    assert "Setting the starting number of the list is not supported!" in caplog.text
 
 
 def test_render_headers():

--- a/tests/test_latex.py
+++ b/tests/test_latex.py
@@ -57,7 +57,7 @@ def test_render_format():
 def test_render_unordered_list():
     markdown = """\
         Items:
-        
+
         * Item 1
         * Item 2
         * Item 3
@@ -66,7 +66,7 @@ def test_render_unordered_list():
         \\documentclass{article}
         \\begin{document}
         Items:
-        
+
         \\begin{itemize}
         \\item Item 1
         \\item Item 2
@@ -81,7 +81,7 @@ def test_render_unordered_list():
 def test_render_ordered_list():
     markdown = """\
         Items:
-        
+
         1. Item 1
         1. Item 2
         1. Item 3
@@ -90,7 +90,7 @@ def test_render_ordered_list():
         \\documentclass{article}
         \\begin{document}
         Items:
-        
+
         \\begin{enumerate}
         \\item Item 1
         \\item Item 2
@@ -105,7 +105,7 @@ def test_render_ordered_list():
 def test_render_ordered_list_change_start(caplog):
     markdown = """\
         Items:
-        
+
         5. Item 5
         5. Item 6
         """
@@ -113,7 +113,7 @@ def test_render_ordered_list_change_start(caplog):
         \\documentclass{article}
         \\begin{document}
         Items:
-        
+
         \\begin{enumerate}
         \\item Item 5
         \\item Item 6

--- a/tests/test_latex.py
+++ b/tests/test_latex.py
@@ -2,7 +2,6 @@ from textwrap import dedent
 
 from marko import Markdown
 from marko.ext.latex_renderer import LatexRenderer
-from marko.ast_renderer import ASTRenderer
 
 
 def test_render_paragraph():
@@ -133,10 +132,10 @@ def test_render_headers():
         \\part*{Header 1}
         Paragraph 1.
 
-        \\section*{Header 2}
+        \\section{Header 2}
         Paragraph 2.
 
-        \\subsection*{Header 3}
+        \\subsection{Header 3}
         Paragraph 3.
 
         \\subsubsection*{Header 4}
@@ -151,12 +150,16 @@ def test_render_headers():
         \\part*{Alternate Header 1}
         Alternate 1
 
-        \\section*{Alternate Header 2}
+        \\section{Alternate Header 2}
         Alternate 2
         \\end{document}
         """
 
-    _assert_latex(markdown, latex)
+    md = Markdown()
+    parsed = md.parse(dedent(markdown))
+    renderer = LatexRenderer(numbered_headers=[2, "subsection"])  # number section and subsection
+    with renderer as r:
+        assert r.render(parsed) == dedent(latex)
 
 
 def test_render_code():
@@ -307,7 +310,5 @@ def test_render_html(caplog):
 
 
 def _assert_latex(markdown: str, latex: str):
-    ast_converter = Markdown(renderer=ASTRenderer)
-    print(ast_converter(dedent(markdown)))
-    latex_converter = Markdown(renderer=LatexRenderer)
-    assert latex_converter(dedent(markdown)) == dedent(latex)
+    md = Markdown(renderer=LatexRenderer)
+    assert md.convert(dedent(markdown)) == dedent(latex)

--- a/tests/test_latex.py
+++ b/tests/test_latex.py
@@ -12,17 +12,17 @@ def test_render_paragraph():
         This is
          another paragraph.
 
-        This has line    
+        This has line
            break!
         """
     latex = """\
         \\documentclass{article}
         \\begin{document}
         This is a paragraph.
-        
+
         This is
         another paragraph.
-        
+
         This has line\\\\
         break!
         \\end{document}
@@ -103,19 +103,19 @@ def test_render_headers():
     markdown = """\
         # Header 1
         Paragraph 1.
-        
+
         ## Header 2
         Paragraph 2.
-        
+
         ### Header 3
         Paragraph 3.
-        
+
         #### Header 4
         Paragraph 4.
-        
+
         ##### Header 5
         Paragraph 5.
-        
+
         ###### Header 6
         Paragraph 6.
 
@@ -244,8 +244,8 @@ def test_render_quote():
 def test_render_thematic_break():
     markdown = """\
         This paragraph is above the horizontal line.
-        
-        * * * 
+
+        ---
 
         While this paragraph is below the horizontal line.
         """
@@ -253,7 +253,7 @@ def test_render_thematic_break():
         \\documentclass{article}
         \\begin{document}
         This paragraph is above the horizontal line.
-        
+
         \\noindent\\rule{\\textwidth}{1pt}
 
         While this paragraph is below the horizontal line.


### PR DESCRIPTION
Implement a basic LaTeX renderer.

Some functionality might be added later, including:
* Render HTML tags.
* Allow changing the start number of an ordered list.
* Add step in CI to generate a PDF file to make sure `pdflatex` command is working.