### PR TITLE
Fixed ordered list markdown renderer.

### DIFF
--- a/marko/md_renderer.py
+++ b/marko/md_renderer.py
@@ -46,7 +46,7 @@ class MarkdownRenderer(Renderer):
         result = []
         if element.ordered:
             num = element.start
-            for child in element.children:
+            for num, child in enumerate(element.children, element.start):
                 with self.container(f"{num}. ", " " * (len(str(num)) + 2)):
                     result.append(self.render(child))
                 num += 1

--- a/marko/md_renderer.py
+++ b/marko/md_renderer.py
@@ -49,6 +49,7 @@ class MarkdownRenderer(Renderer):
             for child in element.children:
                 with self.container(f"{num}. ", " " * (len(str(num)) + 2)):
                     result.append(self.render(child))
+                num += 1
         else:
             for child in element.children:
                 with self.container(f"{element.bullet} ", "  "):

--- a/marko/md_renderer.py
+++ b/marko/md_renderer.py
@@ -45,11 +45,9 @@ class MarkdownRenderer(Renderer):
     def render_list(self, element: "block.List") -> str:
         result = []
         if element.ordered:
-            num = element.start
             for num, child in enumerate(element.children, element.start):
                 with self.container(f"{num}. ", " " * (len(str(num)) + 2)):
                     result.append(self.render(child))
-                num += 1
         else:
             for child in element.children:
                 with self.container(f"{element.bullet} ", "  "):


### PR DESCRIPTION
Hi,
first of all, thanks for creating this library! That was just what I needed right now. I stumbled over a bug however, which caused ordered lists to not be enumerated correctly if rendered using the MarkdownRenderer.

This can be reproduced like that:
``` python
import marko
from marko.md_renderer import MarkdownRenderer

md = marko.Markdown(renderer=MarkdownRenderer)
doc = md.parse("""
1. a
2. b
3. c
""")
print(md.render(doc))
```
Prints:
```
1. a
1. b
1. c
```
The fix is kinda hacky though. I also didn't add tests...