### PR TITLE
Make strikethrough precedence the default; add strikethrough tests

### DIFF
--- a/marko/ext/gfm/elements.py
+++ b/marko/ext/gfm/elements.py
@@ -23,7 +23,7 @@ class Paragraph(block.Paragraph):
 class Strikethrough(inline.InlineElement):
 
     pattern = re.compile(r"~~([^~]+)~~")
-    priority = 4
+    priority = 5
     parse_children = True
 
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -5,7 +5,7 @@ import nox
 os.environ.update(PDM_IGNORE_SAVED_PYTHON="1")
 
 
-@nox.session(python=["3.6", "3.8", "3.9", "3.10"])
+@nox.session(python=["3.6", "3.8", "3.9", "3.10", "3.11"])
 def tests(session):
     session.run("pdm", "install", "-d", external=True)
     session.run("pytest", "tests/")

--- a/tests/test_ext.py
+++ b/tests/test_ext.py
@@ -1,5 +1,6 @@
 #! -*- coding: utf-8 -*-
 
+
 from marko import Markdown
 
 
@@ -75,6 +76,38 @@ class TestPangu:
 class TestGFM:
     def setup_method(self):
         self.markdown = Markdown(extensions=["gfm"])
+
+    def test_strikethrough_link(self):
+        content = "~~[google](https://google.com)~~"
+        assert (
+            self.markdown(content).strip()
+            == '<p><del><a href="https://google.com">google</a></del></p>'
+        )
+
+    def test_strikethrough_inside_link(self):
+        content = "[~~google~~](https://google.com)"
+        assert (
+            self.markdown(content).strip()
+            == '<p><a href="https://google.com"><del>google</del></a></p>'
+        )
+
+    def test_strikethrough_spec_standard(self):
+        content = "~~Hi~~ Hello, world!"
+        expected = "<p><del>Hi</del> Hello, world!</p>"
+        assert self.markdown(content).strip() == expected
+
+    def test_strikethrough_spec_new_paragraph(self):
+        content = """This ~~has a
+
+new paragraph~~."""
+        expected = """<p>This ~~has a</p>
+<p>new paragraph~~.</p>"""
+        assert self.markdown(content).strip() == expected
+
+    def test_strikethrough_spec_wont_strike(self):
+        content = "This will ~~~not~~~ strike."
+        expected = "<p>This will ~~~not~~~ strike.</p>"
+        assert self.markdown(content).strip() == expected
 
     def test_gfm_autolink(self):
         content = "地址：https://google.com"

--- a/tests/test_ext.py
+++ b/tests/test_ext.py
@@ -1,5 +1,6 @@
 #! -*- coding: utf-8 -*-
 
+import pytest
 
 from marko import Markdown
 
@@ -104,6 +105,7 @@ new paragraph~~."""
 <p>new paragraph~~.</p>"""
         assert self.markdown(content).strip() == expected
 
+    @pytest.mark.skip(reason="existing GFM won't-strike bug")
     def test_strikethrough_spec_wont_strike(self):
         content = "This will ~~~not~~~ strike."
         expected = "<p>This will ~~~not~~~ strike.</p>"


### PR DESCRIPTION
I noticed that strikethroughs were parsing incorrectly. If they have lower precedence than a link, then they'll break both themselves and the link!

I added a test for that case, as well as for examples from the GFM spec. I also added python 3.11 to the list of nox pythons.

The example for triple-strikes not changing into `<del>` still doesn't pass, but that seems more involved to fix, and should be a separate issue / PR.