### PR TITLE
Bugfix: Converted BlockElement class variables to instance variables

### DIFF
--- a/marko/block.py
+++ b/marko/block.py
@@ -514,8 +514,8 @@ class ListItem(BlockElement):
         bullet: str
         mid: int
 
-    def __init__(self, info: ListItem.ParseInfo) -> None:
-        super().__init__(virtual=True)
+    def __init__(self, info: ListItem.ParseInfo, **kwargs) -> None:
+        super().__init__(virtual=True, **kwargs)
         indent, bullet, mid = info
         self._prefix = " " * indent + re.escape(bullet) + " " * mid
         self._second_prefix = " " * (len(bullet) + indent + (mid or 1))

--- a/marko/ext/footnote.py
+++ b/marko/ext/footnote.py
@@ -28,9 +28,9 @@ class Document(block.Document):
 
 class FootnoteDef(block.BlockElement):
     pattern = re.compile(r" {,3}\[\^([^\]]+)\]:[^\n\S]*(?=\S| {4})")
-    priority = 6
 
     def __init__(self, match):
+        super().__init__(priority=6)
         self.label = helpers.normalize_label(match.group(1))
         self._prefix = re.escape(match.group())
         self._second_prefix = r" {1,4}"

--- a/marko/ext/gfm/elements.py
+++ b/marko/ext/gfm/elements.py
@@ -106,14 +106,14 @@ class Url(inline.AutoLink):
 
 class ListItem(block.ListItem):
     pattern = re.compile(r" {,3}(\d{1,9}[.)]|[*\-+])[ \t\n\r\f]")
-    override = True
+    def __init__(self) -> None:
+        super().__init__(override=True)
 
 
 class Table(block.BlockElement):
     """A table element."""
 
     _num_of_cols = None
-    _prefix = ""
 
     @classmethod
     def match(cls, source):
@@ -174,12 +174,11 @@ class TableRow(block.BlockElement):
 
     splitter = re.compile(r"\s*(?<!\\)\|\s*")
     delimiter = re.compile(r":?-+:?")
-    virtual = True
     _cells = None
     _is_delimiter = False
 
-    def __init__(self, cells):
-        self.children = cells
+    def __init__(self, cells) -> None:
+        super().__init__(virtual=True, children=cells)
 
     @classmethod
     def match(cls, source):
@@ -216,9 +215,8 @@ class TableRow(block.BlockElement):
 class TableCell(block.BlockElement):
     """A table cell element."""
 
-    virtual = True
-
     def __init__(self, text):
+        super().__init__(virtual=True)
         self.inline_body = text.strip().replace("\\|", "|")
         self.header = False
         self.align = None


### PR DESCRIPTION
I was trying to build a simple script to divide a markdown file into multiple markdown files depending on the contents of a Heading. I did this by creating multiple `marko.block.Document` objects:

```
before_heading = marko.block.Document()
after_heading = mark.block.Document()

# inside of a for loop
if before:
  before_heading.children.append(child)
else:
  after_heading.children.append(child)
```

To my surprise both of the `Document` objects had all of the `child` elements in them because they were sharing a class variable and not an instance variable. Looking at how the classes are organized, I believe you may be able to achieve a similar style with https://docs.python.org/3/library/dataclasses.html

But I don't know how well that will work with the class hierarchy you've built and I wouldn't recommend doing that. So instead I've converted your class variables to instance variables so sneaky things don't happen to other people who want to have multiple `Document` objects in the same process.

I'm open to suggestions, please consider this a WIP.