### PR TITLE
feat: add Gemtext renderer

### DIFF
--- a/marko/ext/gemtext_renderer.py
+++ b/marko/ext/gemtext_renderer.py
@@ -99,7 +99,7 @@ class GemtextRenderer(Renderer):
 
     def render_plain_text(self, element: Any) -> str:
         if isinstance(element.children, str):
-            return self.escape_html(element.children)
+            return element.children
         return self.render_children(element)
 
     def render_image(self, element: inline.Image) -> str:

--- a/marko/gemtext_renderer.py
+++ b/marko/gemtext_renderer.py
@@ -1,0 +1,121 @@
+"""
+A renderer for Gemtext (https://gemini.circumlunar.space/).
+"""
+from typing import Any, Iterator, Union, cast
+
+from . import block, inline
+from .renderer import Renderer
+
+
+def extract_links(
+    paragraph,
+) -> Iterator[Union[inline.Link, inline.AutoLink]]:
+    """Extract links from a paragraph."""
+    queue = [paragraph]
+    while queue:
+        element = queue.pop(0)
+
+        if isinstance(element, (inline.Link, inline.AutoLink)):
+            yield element
+        elif hasattr(element, "children"):
+            queue.extend(element.children)
+
+
+class GemtextRenderer(Renderer):
+
+    """
+    Render Markdown to Gemtext.
+    """
+
+    def render_paragraph(self, element: block.Paragraph) -> str:
+        """
+        Render a paragraph.
+
+        Links are collected and displayed after the paragraph.
+        """
+        paragraph = self.render_children(element) + "\n"
+
+        links = list(extract_links(element))
+        if not links:
+            return paragraph
+
+        return (
+            paragraph
+            + "\n"
+            + "\n".join(self._render_paragraph_link(link) for link in links)
+            + "\n"
+        )
+
+    def _render_paragraph_link(
+        self, element: Union[inline.Link, inline.AutoLink]
+    ) -> str:
+        if element.title:
+            return f"=> {element.dest} {element.title}"
+
+        return f"=> {element.dest} {self.render_children(element)}"
+
+    def render_list(self, element: block.List) -> str:
+        return self.render_children(element)
+
+    def render_list_item(self, element: block.ListItem) -> str:
+        return "* " + self.render_children(element)
+
+    def render_quote(self, element: block.Quote) -> str:
+        return "\n".join(
+            f"> {line}" if line else ""
+            for line in self.render_children(element).split("\n")
+        )
+
+    def render_fenced_code(self, element: block.FencedCode) -> str:
+        """
+        Render code inside triple backticks.
+        """
+        return "```\n" + self.render_children(element) + "```\n"
+
+    def render_code_block(self, element: block.CodeBlock) -> str:
+        return self.render_fenced_code(cast("block.FencedCode", element))
+
+    def render_html_block(self, element: block.HTMLBlock) -> str:
+        return element.body
+
+    def render_thematic_break(self, element: block.ThematicBreak) -> str:
+        return "---\n"
+
+    def render_heading(self, element: block.Heading) -> str:
+        level: int = min(element.level, 3)
+        return "#" * level + " " + self.render_children(element) + "\n"
+
+    def render_setext_heading(self, element: block.SetextHeading) -> str:
+        return self.render_heading(cast("block.Heading", element))
+
+    def render_blank_line(self, element: block.BlankLine) -> str:
+        return "\n"
+
+    def render_link_ref_def(self, element: block.LinkRefDef) -> str:
+        return ""
+
+    def render_inline_html(self, element: inline.InlineHTML) -> str:
+        return str(element.children)
+
+    def render_plain_text(self, element: Any) -> str:
+        if isinstance(element.children, str):
+            return self.escape_html(element.children)
+        return self.render_children(element)
+
+    def render_image(self, element: inline.Image) -> str:
+        if element.title:
+            return f"=> {element.dest} {element.title}"
+
+        return f"=> {element.dest} {self.render_children(element)}"
+
+    def render_literal(self, element: inline.Literal) -> str:
+        return str(element.children)
+
+    def render_raw_text(self, element: inline.RawText) -> str:
+        return str(element.children)
+
+    def render_line_break(self, element: inline.LineBreak) -> str:
+        return "\n"
+
+    def render_code_span(self, element: inline.CodeSpan) -> str:
+        return str(element.children)

--- a/tests/test_gemtext.py
+++ b/tests/test_gemtext.py
@@ -1,0 +1,211 @@
+"""
+Tests for the Gemtext renderer.
+"""
+from marko import Markdown
+from marko.gemtext_renderer import GemtextRenderer
+
+
+def test_gemtext_renderer() -> None:
+    """
+    Test ``GemtextRenderer``.
+    """
+    double_space = "  "
+
+    gemini = Markdown(renderer=GemtextRenderer)
+
+    assert (
+        gemini.convert(
+            f"""
+# Header 1
+
+## Header 2
+
+### Header 3
+
+#### Header 4
+
+- Mercury
+- Gemini
+  - Apollo
+
+> This is{double_space}
+> A multiline{double_space}
+> blockquote{double_space}
+
+*This* is a **paragraph**. With `code`.
+
+This is an [inline link](https://example.com/). This is [another](https://example.org/).
+
+```
+This is some code.
+```
+
+End.
+""",
+        )
+        == f"""
+# Header 1
+
+## Header 2
+
+### Header 3
+
+### Header 4
+
+* Mercury
+* Gemini
+* Apollo
+
+> This is
+> A multiline
+> blockquote{double_space}
+
+This is a paragraph. With code.
+
+This is an inline link. This is another.
+
+=> https://example.com/ inline link
+=> https://example.org/ another
+
+```
+This is some code.
+```
+
+End.
+"""
+    )
+
+
+def test_gemini_renderer_link_ref_def() -> None:
+    """
+    Test rendering a link definition reference.
+    """
+    gemini = Markdown(renderer=GemtextRenderer)
+
+    assert (
+        gemini.convert(
+            """
+Hi, here's my [thing that I just casually mention][tt] sometimes.
+
+[tt]: gemini://my.boring/url "I like this link"
+            """,
+        )
+        == """
+Hi, here's my thing that I just casually mention sometimes.
+
+=> gemini://my.boring/url I like this link
+
+
+"""
+    )
+
+
+def test_gemini_renderer_links() -> None:
+    """
+    Test rendering links.
+    """
+    gemini = Markdown(renderer=GemtextRenderer)
+    assert (
+        gemini.convert(
+            """
+This is a paragraph with [a link](https://example.com/). It is a good paragraph.
+
+This one [also has a link](https://example.net/). It also has some *emphasis* and **bold**.
+
+And this one is a special paragraph because it has not just [one](https://example.com/one),
+but [two](https://example.com/two) links. That is quite a lot.
+
+This other paragraph also has [a link][ref], using a reference. It's very fancy.
+
+[ref]: https://example.org/foo "This is foo"
+
+This one has an auto link <https://example.com/autolink>.
+
+That is it.
+            """,
+        )
+        == """
+This is a paragraph with a link. It is a good paragraph.
+
+=> https://example.com/ a link
+
+This one also has a link. It also has some emphasis and bold.
+
+=> https://example.net/ also has a link
+
+And this one is a special paragraph because it has not just one,
+but two links. That is quite a lot.
+
+=> https://example.com/one one
+=> https://example.com/two two
+
+This other paragraph also has a link, using a reference. It's very fancy.
+
+=> https://example.org/foo This is foo
+
+
+This one has an auto link https://example.com/autolink.
+
+=> https://example.com/autolink https://example.com/autolink
+
+That is it.
+
+"""
+    )
+
+
+def test_gemini_renderer_padding_after_link_ref_def() -> None:
+    """
+    Test the padding after a link reference definition.
+
+    Ideally we shouldn't be left with an empty line.
+    """
+    gemini = Markdown(renderer=GemtextRenderer)
+    assert (
+        gemini.convert(
+            """
+This other paragraph also has [a link][ref], using a reference. It's very fancy.
+
+[ref]: https://example.org/foo "This is foo"
+
+That is it.
+""",
+        )
+        == """
+This other paragraph also has a link, using a reference. It's very fancy.
+
+=> https://example.org/foo This is foo
+
+
+That is it.
+"""
+    )
+
+
+def test_gemini_renderer_image() -> None:
+    """
+    Test rendering images.
+    """
+    gemini = Markdown(renderer=GemtextRenderer)
+    assert (
+        gemini.convert(
+            """
+This is a paragraph.
+
+![Alt text](https://assets.digitalocean.com/articles/alligator/boo.svg "a title")
+
+![Alt text](https://assets.digitalocean.com/articles/alligator/boo.svg)
+
+That is it.
+""",
+        )
+        == """
+This is a paragraph.
+
+=> https://assets.digitalocean.com/articles/alligator/boo.svg a title
+
+=> https://assets.digitalocean.com/articles/alligator/boo.svg Alt text
+
+That is it.
+"""
+    )

--- a/tests/test_gemtext.py
+++ b/tests/test_gemtext.py
@@ -2,7 +2,7 @@
 Tests for the Gemtext renderer.
 """
 from marko import Markdown
-from marko.gemtext_renderer import GemtextRenderer
+from marko.ext.gemtext_renderer import GemtextRenderer
 
 
 def test_gemtext_renderer() -> None:


### PR DESCRIPTION
A renderer for [Gemtext](https://gemini.circumlunar.space/docs/gemtext.gmi), used in the [Gemini protol](https://gemini.circumlunar.space/).

I've been using this on my Gemini capsule (gemini://taoetc.org/) for years, and thought it could be useful to more people.