### PR TITLE
Initialize children in Document.__init__()

### DIFF
--- a/marko/block.py
+++ b/marko/block.py
@@ -79,6 +79,7 @@ class Document(BlockElement):
 
     def __init__(self) -> None:
         super().__init__()
+        self.children = []
         self.link_ref_defs: dict[str, tuple[str, str]] = {}
 
 

--- a/marko/block.py
+++ b/marko/block.py
@@ -78,7 +78,6 @@ class Document(BlockElement):
     virtual = True
 
     def __init__(self) -> None:
-        super().__init__()
         self.children = []
         self.link_ref_defs: dict[str, tuple[str, str]] = {}
 


### PR DESCRIPTION
I'm using Marko to parse a Markdown document, split it into multiple documents according to some headings, and then render each of those sub-documents separately. While in the process of doing this, I discovered a strange behaviour:

```python
>>> from marko.block import Document
>>> d1 = Document()
>>> d1.children.append(1)
>>> d1
<Document children=[1]>
>>> d1.children
[1]
>>> d2 = Document()
>>> d2
<Document children=[1]>
>>> d2.children
[1]
```

Looking at Marko's code, it's because you [define and assign](https://github.com/frostming/marko/blob/master/marko/block.py#L38) `children = []` as a class variable on `BlockElement`, and then rely on each subclass to re-initialize it. But, I guess since Document is meant to be virtual, it doesn't do that. So any manually-constructed Document will share the same instance of `children`, which I'm sure is not intended.

Perhaps what I'm missing is some other way to accomplish the goal of constructing a Document object (which can then be `render()`-ed) from a sequence of Nodes (filtered out of another Document), rather than from a string. But I don't think this is currently possible, so the only way to do this is to break the virtual-ness of Document and just initialize one. In which case, something like this PR is required.