### PR TITLE
fix: correct LinkRefDef line break handling​

### DIFF
--- a/marko/block.py
+++ b/marko/block.py
@@ -619,7 +619,7 @@ class LinkRefDef(BlockElement):
         if end >= 0:
             end += 1
         else:
-            end = i
+            end = len(text)
         if text[i:end].strip():
             if link_title.text and "\n" in text[link_dest.end : link_title.start]:
                 link_title = inline_parser._EMPTY_GROUP

--- a/tests/test_spec.py
+++ b/tests/test_spec.py
@@ -69,7 +69,12 @@ COMMON_CASES = [
         "mixed_tab_space_in_list_item",
         "* foo\n\t* foo.bar",
         "<ul><li>foo<ul><li>foo.bar</li></ul></li></ul>",
-    )
+    ),
+    (
+        "non_whitespace_after_title_is_not_link_ref_def",
+        '[foo]: /url "title" ok',  # Same as spec but no line breaks.
+        '<p>[foo]: /url &quot;title&quot; ok</p>',
+    ),
 ]
 
 CMARK_CASES = [


### PR DESCRIPTION
'[foo]: /url "title" ok', without \n, should not be recognized as a LinkRefDef