### PR TITLE
Fix mis-spelled textarea in regex for escaping

### DIFF
--- a/marko/ext/gfm/renderer.py
+++ b/marko/ext/gfm/renderer.py
@@ -10,11 +10,11 @@ from marko.md_renderer import MarkdownRenderer
 
 class GFMRendererMixin:
     tagfilter = re.compile(
-        r"<(title|texarea|style|xmp|iframe|noembed|noframes|script|plaintext)",
+        r"<(title|textarea|style|xmp|iframe|noembed|noframes|script|plaintext)",
         flags=re.I,
     )
     tagfilter_no_open = re.compile(
-        r"(?<!^)( *)<(title|texarea|style|xmp|iframe|noembed|noframes|script|plaintext)",
+        r"(?<!^)( *)<(title|textarea|style|xmp|iframe|noembed|noframes|script|plaintext)",
         flags=re.I,
     )
 


### PR DESCRIPTION
Fixes https://github.com/frostming/marko/issues/243.

It's a great library, by the way! Thank you for making it.