### PR TITLE
feat: allow extension blocks to break a Paragraph

### DIFF
--- a/marko/block.py
+++ b/marko/block.py
@@ -45,6 +45,8 @@ class BlockElement(Element):
     inline_body: str = ""
     #: If true, will replace the element which it derives from.
     override = False
+    #: If true, the element can break (end) a Paragraph block.
+    breaks_paragraph = False
     _prefix = ""
 
     @classmethod
@@ -86,6 +88,7 @@ class BlankLine(BlockElement):
     """Blank lines"""
 
     priority = 5
+    breaks_paragraph = True
 
     def __init__(self, start: int) -> None:
         self._anchor = start
@@ -111,6 +114,7 @@ class Heading(BlockElement):
         r" {0,3}(#{1,6})((?=\s)[^\n]*?|[^\n\S]*)(?:(?<=\s)(?<!\\)#+)?[^\n\S]*$\n?",
         flags=re.M,
     )
+    breaks_paragraph = True
 
     def __init__(self, match: Match[str]) -> None:
         self.level = len(match.group(1))
@@ -207,6 +211,7 @@ class FencedCode(BlockElement):
 
     priority = 7
     pattern = re.compile(r"( {,3})(`{3,}|~{3,})[^\n\S]*(.*?)$", re.M)
+    breaks_paragraph = True
 
     class ParseInfo(NamedTuple):
         prefix: str
@@ -357,11 +362,10 @@ class Paragraph(BlockElement):
         parser = source.parser
         prev_match = source.match
         try:
+            elements = parser.block_elements.values()
+            breaking_elements = [element for element in elements if element.breaks_paragraph]
             if (
-                parser.block_elements["Quote"].match(source)
-                or parser.block_elements["Heading"].match(source)
-                or parser.block_elements["BlankLine"].match(source)
-                or parser.block_elements["FencedCode"].match(source)
+                any(element.match(source) for element in breaking_elements)
             ):
                 return True
             if (
@@ -428,6 +432,7 @@ class Quote(BlockElement):
     """block quote element: (> hello world)"""
 
     priority = 6
+    breaks_paragraph = True
     _prefix = r" {,3}>[^\n\S]?"
 
     @classmethod

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -193,5 +193,7 @@ class TestExtension:
         res = md.parse(text)
 
         assert len(res.children) == 4
+        assert isinstance(res.children[0], block.BlankLine)
         assert isinstance(res.children[1], block.Paragraph)
         assert isinstance(res.children[2], CustomElement)
+        assert isinstance(res.children[3], block.BlankLine)

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -171,11 +171,11 @@ class TestExtension:
 
 
             @classmethod
-            def match(cls, source: Source) -> re.Match[str] | None:
+            def match(cls, source: Source) -> "re.Match[str] | None":
                 return source.expect_re(cls.pattern)
 
             @classmethod
-            def parse(cls, source: Source) -> re.Match[str] | None:
+            def parse(cls, source: Source) -> "re.Match[str] | None":
                 m = source.match
                 source.consume()
                 return m

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -1,6 +1,8 @@
 #! -*- coding: utf-8 -*-
+import re
 import textwrap
 
+from marko.source import Source
 import pytest
 
 import marko
@@ -158,3 +160,38 @@ class TestExtension:
         md = marko.Markdown(extensions=["gfm", "footnote"], renderer=MarkdownRenderer)
         res = md.convert(text)
         assert res == text
+
+    def test_paragraph_breaking_element(self):
+        class CustomElement(block.BlockElement):
+            breaks_paragraph = True
+            pattern = re.compile(r" {,3}@broken (.*)", flags=re.M)
+
+            def __init__(self, match: re.Match[str]) -> None:
+                self.inline_body = match.group(1).strip()
+
+
+            @classmethod
+            def match(cls, source: Source) -> re.Match[str] | None:
+                return source.expect_re(cls.pattern)
+
+            @classmethod
+            def parse(cls, source: Source) -> re.Match[str] | None:
+                m = source.match
+                source.consume()
+                return m
+
+        my_extension = marko.MarkoExtension(elements=[CustomElement])
+
+        text = textwrap.dedent(
+            """
+            some text that is
+            @broken by a custom element
+            """
+        )
+
+        md = marko.Markdown(extensions=[my_extension])
+        res = md.parse(text)
+
+        assert len(res.children) == 4
+        assert isinstance(res.children[1], block.Paragraph)
+        assert isinstance(res.children[2], CustomElement)


### PR DESCRIPTION
Currently the list of elements that can break a Paragraph is hardwired in the Paragraph implementation.

This PR suggests a new BlockElement property `breaks_paragraph` that allows extensions to define blocks that can also break a paragraph without the need to override the Paragraph `break_paragraph` implementation.