### PR TITLE
Replace U+0000 with U+FFFD on input per CommonMark §2.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Fix a potential security issue in the URL escaping logic of the Markdown renderer.
 - Fix GFM table indentation in list.
 - Fix an infinite loop caused by unnormalized line breaks.
+- Replace literal U+0000 (NUL) with U+FFFD on input, per CommonMark §2.3.
 
 ## v2.2.2(2026-01-05)
 

--- a/marko/source.py
+++ b/marko/source.py
@@ -16,7 +16,8 @@ if TYPE_CHECKING:
 
 def _preprocess_text(text: str) -> str:
     # Normalize line terminators so block parsers can always advance on line reads.
-    return text.replace("\r\n", "\n").replace("\r", "\n").replace("\f", "\n")
+    text = text.replace("\r\n", "\n").replace("\r", "\n").replace("\f", "\n")
+    return text.replace("\x00", "�")
 
 
 class Source:

--- a/tests/test_spec.py
+++ b/tests/test_spec.py
@@ -94,7 +94,22 @@ CMARK_CASES = [
         "emphasis_underscore_in_strong",
         "**a_{b}**",
         "<p><strong>a_{b}</strong></p>",
-    )
+    ),
+    (
+        "insecure_null_in_text",
+        "a\x00b",
+        "<p>a�b</p>",
+    ),
+    (
+        "insecure_null_in_code_span",
+        "`a\x00b`",
+        "<p><code>a�b</code></p>",
+    ),
+    (
+        "insecure_null_in_fenced_code",
+        "```\na\x00b\n```",
+        "<pre><code>a�b\n</code></pre>",
+    ),
 ]
 
 


### PR DESCRIPTION
## Summary

CommonMark §2.3 requires literal `U+0000` characters to be replaced with `U+FFFD`.
Marko already does this for entity references like `&#0;` and `&#x0;`, but literal NUL characters in the input are currently preserved in the rendered HTML.

## Reproduction

```python
import marko
print(repr(marko.convert("a\x00b")))
# current:  '<p>a\x00b</p>\n'
# expected: '<p>a�b</p>\n'

print(repr(marko.convert("`a\x00b`")))
# current: '<p><code>a\x00b</code></p>\n'

print(repr(marko.convert("&#0;")))
# already correct: '<p>�</p>\n'
```

The same issue also happens inside fenced code blocks.

## Fix

Apply the `\x00` to `�` substitution in `_preprocess_text()` after line-ending normalization.
This makes all parser and renderer paths see the same sanitized input, and keeps the behavior consistent with the existing entity-reference handling.

## Tests

Added regression tests for:

- NUL in plain text
- NUL inside a code span
- NUL inside a fenced code block

All existing tests still pass.