### PR TITLE
Minor typing fixes

### DIFF
--- a/marko/ast_renderer.py
+++ b/marko/ast_renderer.py
@@ -109,13 +109,13 @@ class XMLRenderer(Renderer):
         children = getattr(element, "body", None) or getattr(element, "children", None)
         if children:
             self.indent += 2
-            if isinstance(children, str):  # type: ignore
+            if isinstance(children, str):
                 lines.append(
                     " " * self.indent
-                    + HTMLRenderer.escape_html(json.dumps(children)[1:-1])  # type: ignore
+                    + HTMLRenderer.escape_html(json.dumps(children)[1:-1])
                 )
             else:
-                lines.extend(self.render(child) for child in children)  # type: ignore
+                lines.extend(self.render(child) for child in children)
             self.indent -= 2
             lines.append(" " * self.indent + f"</{element_name}>")
         else:

--- a/marko/block.py
+++ b/marko/block.py
@@ -393,7 +393,7 @@ class Paragraph(BlockElement):
 
     @classmethod
     def parse(cls, source: Source) -> list[str] | SetextHeading:
-        lines = [cast(str, source.next_line())]
+        lines = [source.next_line()]
         source.consume()
         end_parse = False
         while not source.exhausted and not end_parse:
@@ -547,7 +547,7 @@ class ListItem(BlockElement):
             return False
         if not source.expect_re(cls.pattern):
             return False
-        next_line = cast(str, source.next_line(False)).expandtabs(4)
+        next_line = source.next_line(False).expandtabs(4)
         prefix_pos = 0
         m = re.match(source.prefix, next_line)
         if m is not None:

--- a/marko/block.py
+++ b/marko/block.py
@@ -571,9 +571,9 @@ class ListItem(BlockElement):
         state = cls(source.context.list_item_info)
         state.children = []
         with source.under_state(state):
-            if not source.next_line().strip():  # type: ignore[union-attr]
+            if not source.next_line().strip():
                 source.consume()
-                if not source.next_line() or not source.next_line().strip():  # type: ignore[union-attr]
+                if not source.next_line() or not source.next_line().strip():
                     return state
             state.children = source.parser.parse_source(source)
         if isinstance(state.children[-1], BlankLine):

--- a/marko/ext/codehilite.py
+++ b/marko/ext/codehilite.py
@@ -18,6 +18,7 @@ Usage::
 """
 
 import json
+from typing import TYPE_CHECKING
 
 from pygments import highlight
 from pygments.formatters import html
@@ -26,6 +27,9 @@ from pygments.util import ClassNotFound
 
 from marko import HTMLRenderer
 from marko.helpers import MarkoExtension, render_dispatch
+
+if TYPE_CHECKING:
+    from typing import Any
 
 
 def _parse_extras(line):
@@ -44,7 +48,7 @@ def _parse_extras(line):
 
 
 class CodeHiliteRendererMixin:
-    options = {}  # type: dict
+    options: dict[str, Any] = {}
 
     @render_dispatch(HTMLRenderer)
     def render_fenced_code(self, element):

--- a/marko/ext/codehilite.py
+++ b/marko/ext/codehilite.py
@@ -17,6 +17,8 @@ Usage::
     markdown.convert('```python filename="my_script.py"\nprint('hello world')\n```')
 """
 
+from __future__ import annotations
+
 import json
 from typing import TYPE_CHECKING
 

--- a/marko/ext/toc.py
+++ b/marko/ext/toc.py
@@ -25,7 +25,7 @@ Usage::
 
 import re
 
-from marko.helpers import MarkoExtension, render_dispatch  # type: ignore
+from marko.helpers import MarkoExtension, render_dispatch
 from marko.html_renderer import HTMLRenderer
 
 try:

--- a/marko/html_renderer.py
+++ b/marko/html_renderer.py
@@ -21,7 +21,7 @@ class HTMLRenderer(Renderer):
 
     def render_paragraph(self, element: block.Paragraph) -> str:
         children = self.render_children(element)
-        if element._tight:  # type: ignore
+        if element._tight:
             return children
         else:
             return f"<p>{children}</p>\n"
@@ -38,7 +38,7 @@ class HTMLRenderer(Renderer):
         )
 
     def render_list_item(self, element: block.ListItem) -> str:
-        if len(element.children) == 1 and getattr(element.children[0], "_tight", False):  # type: ignore
+        if len(element.children) == 1 and getattr(element.children[0], "_tight", False):
             sep = ""
         else:
             sep = "\n"

--- a/marko/inline.py
+++ b/marko/inline.py
@@ -69,7 +69,7 @@ class Literal(InlineElement):
 
     @classmethod
     def strip_backslash(cls, text: str) -> str:
-        return cls.pattern.sub(r"\1", text)  # type: ignore[unio]
+        return cls.pattern.sub(r"\1", text)
 
 
 class LineBreak(InlineElement):

--- a/marko/md_renderer.py
+++ b/marko/md_renderer.py
@@ -93,7 +93,7 @@ class MarkdownRenderer(Renderer):
         return "\n".join(lines) + "\n"
 
     def render_html_block(self, element: block.HTMLBlock) -> str:
-        result = self._prefix + element.body + "\n"  # type: ignore[attr-defined]
+        result = self._prefix + element.body + "\n"
         self._prefix = self._second_prefix
         return result
 

--- a/marko/renderer.py
+++ b/marko/renderer.py
@@ -91,7 +91,7 @@ class Renderer:
 
         :param element: a branch node who has children attribute.
         """
-        rendered = [self.render(child) for child in element.children]  # type: ignore
+        rendered = [self.render(child) for child in element.children]
         return "".join(rendered)
 
 

--- a/marko/renderer.py
+++ b/marko/renderer.py
@@ -95,7 +95,8 @@ class Renderer:
         return "".join(rendered)
 
 
-_F = TypeVar("_F", bound=Callable)
+_FT = TypeVar("_FT")
+_F = TypeVar("_F", bound=Callable[..., _FT])
 
 
 def force_delegate(func: _F) -> _F:

--- a/marko/source.py
+++ b/marko/source.py
@@ -104,7 +104,7 @@ class Source:
         """
         prefix_len = self.match_prefix(
             self.prefix,
-            self.next_line(require_prefix=False),  # type: ignore
+            self.next_line(require_prefix=False),
         )
         if prefix_len >= 0:
             match = self._expect_re(regexp, self.pos + prefix_len)
@@ -154,4 +154,4 @@ class Source:
     def _update_prefix(self) -> None:
         for s in self._states:
             if hasattr(s, "_second_prefix"):
-                s._prefix = s._second_prefix  # type: ignore
+                s._prefix = s._second_prefix

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,3 +75,8 @@ without-hashes = true
 
 [tool.isort]
 profile = "black"
+
+[[tool.mypy.overrides]]
+# objprint is typed, just missing a py.typed marker
+module = ["objprint.*"]
+follow_untyped_imports = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,6 +61,7 @@ dev = [
     "pytest",
     "pytest-cov",
     "mypy>=0.950",
+    "types-Pygments>=2.19.0.20251121",
 ]
 doc = [
     "marko[toc]",


### PR DESCRIPTION
This is a collection of commits fixing low-hanging typechecking errors: removing unused `type: ignore` directives, adding type stubs for dependencies, and removing redundant casts.