### PR TITLE
Fix quadratic-time linebreak parsing

### DIFF
--- a/marko/inline.py
+++ b/marko/inline.py
@@ -86,6 +86,16 @@ class LineBreak(InlineElement):
         self.soft = not match.group(1).startswith(("  ", "\\"))
         self.children = "\n"
 
+    @classmethod
+    def find(cls, text: str, *, source: Source) -> Iterator[_Match]:
+        """This method should return an iterable containing matches of this element."""
+        # HACK: short circuit to avoid quadratic runtime when text doesn't have a linebreak.
+        # ideally the regex pattern should be rewritten, but this works for now.
+        # see issue #219
+        if '\n' not in text:
+            return []
+        return super().find(text, source=source)
+
 
 class InlineHTML(InlineElement):
     priority = 7

--- a/marko/inline.py
+++ b/marko/inline.py
@@ -92,7 +92,7 @@ class LineBreak(InlineElement):
         # HACK: short circuit to avoid quadratic runtime when text doesn't have a linebreak.
         # ideally the regex pattern should be rewritten, but this works for now.
         # see issue #219
-        if '\n' not in text:
+        if "\n" not in text:
             return []
         return super().find(text, source=source)
 


### PR DESCRIPTION
This is a quick hack to fix issue #219. The regex pattern used for parsing linebreaks combined with the use of `re.finditer` runs in quadratic time when the parsing input doesn't contain a newline character. By checking for the presence of a newline character the problematic pattern can be short-circuited. Ideally a proper fix would fix the regex pattern itself, but this is a useful fix to have in place until the pattern is fixed.

Fixes #219