### PR TITLE
Fix MarkdownRenderer corrupting email autolinks on round-trip

### DIFF
--- a/marko/md_renderer.py
+++ b/marko/md_renderer.py
@@ -157,7 +157,12 @@ class MarkdownRenderer(Renderer):
         return f"[{link_text}]({element.dest}{title})"
 
     def render_auto_link(self, element: inline.AutoLink) -> str:
-        return f"<{element.dest}>"
+        # Render the original text, not ``dest``: for an email autolink
+        # ``AutoLink`` prepends "mailto:" to ``dest`` while keeping the original
+        # address in the children, so emitting ``dest`` would turn
+        # ``<mail@x.com>`` into ``<mailto:mail@x.com>`` and break the round-trip.
+        # For URI autolinks the children equal ``dest``, so they are unchanged.
+        return f"<{self.render_children(element)}>"
 
     def render_image(self, element: inline.Image) -> str:
         template = "![{}]({}{})"

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -64,6 +64,17 @@ class TestBasic:
         rerendered = markdown.convert(text)
         assert rerendered == text
 
+    def test_markdown_renderer_email_autolink(self):
+        # An email autolink must keep its original address, not the synthetic
+        # "mailto:"-prefixed dest, otherwise the round-trip is corrupted.
+        markdown = marko.Markdown(renderer=MarkdownRenderer)
+        assert markdown("<mail@x.com>") == "<mail@x.com>\n"
+        for text in ("<mail@x.com>\n", "<http://example.org>\n"):
+            rerendered = markdown(text)
+            assert normalize_html(marko.convert(rerendered)) == normalize_html(
+                marko.convert(text)
+            )
+
 
 class TestExtension:
     def test_extension_use(self):


### PR DESCRIPTION
## Summary

`MarkdownRenderer` corrupts **email autolinks** when re-rendering Markdown:

```python
import marko
from marko.md_renderer import MarkdownRenderer

md = marko.Markdown(renderer=MarkdownRenderer)
md("<mail@x.com>")   # -> '<mailto:mail@x.com>\n'
```

Re-parsing that output no longer yields the original email link — `<mailto:mail@x.com>` is parsed as a URI autolink, so the rendered HTML link text becomes `mailto:mail@x.com` instead of `mail@x.com`. The `MarkdownRenderer` round-trip is broken for any email autolink. URI autolinks (`<http://example.org>`) round-trip correctly.

## Cause

`AutoLink.__init__` prepends `"mailto:"` to `dest` for emails, but preserves the original address in the children:

```python
self.dest = match.group(1)
if re.match(patterns.email, self.dest):
    self.dest = "mailto:" + self.dest
self.children = [RawText(match.group(1))]
```

`render_auto_link` emitted the synthetic `dest`:

```python
return f"<{element.dest}>"
```

so the `mailto:` prefix leaked into the Markdown output. (The HTML renderer correctly uses the children for the display text.)

## Fix

Render the children — the original text — instead of `dest`. For URI autolinks the children equal `dest`, so they are unchanged:

```python
return f"<{self.render_children(element)}>"
```

## Verification

- Added `test_markdown_renderer_email_autolink`: asserts `<mail@x.com>` re-renders unchanged and that both an email and a URI autolink round-trip to equivalent HTML. It fails before the fix and passes after.
- Verified email autolinks with subdomains / `+`/`-`/`.` in the local part, explicit `<mailto:...>` URIs, and `https` autolinks all round-trip and are idempotent under re-rendering.
- Full suite: **1397 passed** (was 1396). `ruff` and `mypy` clean on the changed files.

This pull request was prepared with the assistance of AI, under my direction and review.
