### PR TITLE
fix: preserve loose list spacing in MarkdownRenderer

### DIFF
--- a/marko/md_renderer.py
+++ b/marko/md_renderer.py
@@ -61,7 +61,8 @@ class MarkdownRenderer(Renderer):
                 with self.container(f"{element.bullet} ", "  "):
                     result.append(self.render(child))
         self._prefix = self._second_prefix
-        return "".join(result)
+        sep = "\n" if not element.tight else ""
+        return sep.join(result)
 
     def render_list_item(self, element: block.ListItem) -> str:
         return self.render_children(element)

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -50,6 +50,23 @@ class TestBasic:
             marko.convert(text)
         )
 
+    def test_markdown_renderer_loose_list(self):
+        # A loose list (items separated by blank lines) must round-trip unchanged.
+        # Before the fix, render_list() emitted tight spacing regardless of
+        # element.tight, converting the loose list to a tight list and producing
+        # different HTML output.
+        for text in (
+            "- item1\n\n- item2\n",
+            "- a\n\n- b\n\n- c\n",
+            "1. first\n\n2. second\n",
+        ):
+            markdown = marko.Markdown(renderer=MarkdownRenderer)
+            rerendered = markdown(text)
+            assert rerendered == text, f"loose list not preserved: {text!r} -> {rerendered!r}"
+            assert normalize_html(marko.convert(rerendered)) == normalize_html(
+                marko.convert(text)
+            )
+
     def test_markdown_renderer_preserve_link_refs(self):
         text = textwrap.dedent(
             """\


### PR DESCRIPTION
## Problem

`MarkdownRenderer.render_list()` always joins rendered list items with
`""`, ignoring the `element.tight` attribute. This means a **loose
list** (items separated by blank lines, `tight=False`) is re-emitted as
a **tight list**, silently changing the document's semantics.

The difference matters: a tight list renders list content as bare text,
while a loose list wraps each item in `<p>` tags.

```python
import marko
from marko.md_renderer import MarkdownRenderer

md = marko.Markdown(renderer=MarkdownRenderer)

# Before the fix:
md("- item1\n\n- item2\n")
# Returns: '- item1\n- item2\n'  ← blank line lost, semantics changed
```

Converting the re-rendered output back to HTML gives different HTML:

| Input | HTML |
|---|---|
| `- item1\n\n- item2\n` (loose) | `<ul><li><p>item1</p></li><li><p>item2</p></li></ul>` |
| `- item1\n- item2\n` (tight) | `<ul><li>item1</li><li>item2</li></ul>` |

## Fix

When `element.tight` is `False`, join the rendered items with `"\n"`
(a blank line) instead of `""`.

## Tests

Added `test_markdown_renderer_loose_list` covering loose unordered
lists, 3-item loose lists, and loose ordered lists — verifying both
exact text round-trip and HTML semantic equivalence.

All 1397 tests pass.