### PR TITLE
fix(footnote): parse footnote definition followed by a tab

### DIFF
--- a/marko/ext/footnote.py
+++ b/marko/ext/footnote.py
@@ -34,7 +34,8 @@ class FootnoteDef(block.BlockElement):
 
     def __init__(self, match):
         self.label = helpers.normalize_label(match.group(1))
-        self._prefix = re.escape(match.group())
+        # expandtabs to match the tab-expanded line; a raw tab loops forever
+        self._prefix = re.escape(match.group().expandtabs(4))
         self._second_prefix = r" {1,4}"
 
     @classmethod

--- a/tests/test_ext.py
+++ b/tests/test_ext.py
@@ -17,6 +17,16 @@ class TestFootnote:
         result = self.markdown("foo[^1]")
         assert result.rstrip() == "<p>foo[^1]</p>"
 
+    def test_footnote_def_separated_by_tab(self):
+        # A footnote definition may use a tab after the colon. The continuation
+        # prefix was built from the raw match (with a literal tab) while lines are
+        # matched tab-expanded, so the tab prefix never re-matched, the body
+        # advanced nothing, and parsing looped forever. It must parse like a space.
+        tabbed = self.markdown("this is a footnote[^1].\n\n[^1]:\tfoo\n")
+        spaced = self.markdown("this is a footnote[^1].\n\n[^1]: foo\n")
+        assert tabbed == spaced
+        assert 'foo<a href="#fnref-1" class="footnote">&#8617;</a>' in tabbed
+
 
 class TestToc:
     def setup_method(self):


### PR DESCRIPTION
A footnote definition whose colon is followed by a tab, e.g. `[^1]:\tfoo`, hangs the parser forever.

`FootnoteDef.pattern` matches the tab as trailing whitespace after the colon, so the definition is accepted. But `FootnoteDef.__init__` builds its continuation prefix from the raw match (`re.escape(match.group())`), which contains a literal tab, while `Source.match_prefix` matches that prefix against the tab-expanded line (`line.expandtabs(4)`). The literal-tab prefix never re-matches the expanded line, the body advances no input, and `parse_source` loops indefinitely. A space after the colon works only because a literal space matches the expanded line byte for byte.

The fix expands tabs in the prefix so it is compared against the same text `match_prefix` sees. `[^1]:\tfoo` now parses identically to `[^1]: foo`.

Repro:

```python
from marko import Markdown
md = Markdown(extensions=["footnote"])
md("[^1]:\tfoo\n")   # hangs before this fix
```

Added `test_footnote_def_separated_by_tab`.
